### PR TITLE
[PDR-12549][bug/sdk]修正在jupyter中无法运行的bug

### DIFF
--- a/pdr_python_sdk/demo/api/hello_world.py
+++ b/pdr_python_sdk/demo/api/hello_world.py
@@ -16,5 +16,5 @@ class HelloWorldApi(OnDemandApi):
 
 
 if __name__ == '__main__':
-    run(HelloWorldApi, sys.argv, sys.stdin.buffer, sys.stdout.buffer)
+    run(HelloWorldApi, sys.argv, sys.stdin.buffer, sys.__stdout__.buffer)
 

--- a/pdr_python_sdk/demo/spl/batch_foobar.py
+++ b/pdr_python_sdk/demo/spl/batch_foobar.py
@@ -13,4 +13,4 @@ class Foobar(SplStreamingBatchCommand):
 
 
 if __name__ == '__main__':
-    run(Foobar, sys.argv, sys.stdin.buffer, sys.stdout.buffer)
+    run(Foobar, sys.argv, sys.stdin.buffer, sys.__stdout__.buffer)

--- a/pdr_python_sdk/demo/spl/chunk_foobar.py
+++ b/pdr_python_sdk/demo/spl/chunk_foobar.py
@@ -13,4 +13,4 @@ class Foobar(SplStreamingChunkCommand):
 
 
 if __name__ == '__main__':
-    run(Foobar, sys.argv, sys.stdin.buffer, sys.stdout.buffer)
+    run(Foobar, sys.argv, sys.stdin.buffer, sys.__stdout__.buffer)

--- a/pdr_python_sdk/pdr_python_sdk/api/on_demand_api.py
+++ b/pdr_python_sdk/pdr_python_sdk/api/on_demand_api.py
@@ -27,7 +27,7 @@ class OnDemandApi(OnDemandAction):
     def __init__(self):
         self.__is_inited = False
         self.__input_stream = sys.stdin.buffer
-        self.__output_stream = sys.stdout.buffer
+        self.__output_stream = sys.__stdout__.buffer
 
     def do_handle_init(self, packet):
         """
@@ -89,14 +89,14 @@ class OnDemandApi(OnDemandAction):
         """
         self.write(packet.to_string())
 
-    def on_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def on_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         """
         default method called when new request arrives.
         in default, this method uses sys.stdin as input stream and sys.stdout as ouput stream
         """
         self.handle_request(argv, input_stream, output_stream)
 
-    def handle_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def handle_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         """
         handle request from given input_stream, and response through given output_stream
         @param argv: cmd arguments

--- a/pdr_python_sdk/pdr_python_sdk/client.py
+++ b/pdr_python_sdk/pdr_python_sdk/client.py
@@ -209,7 +209,6 @@ class PandoraConnection(object):
         This kind of jobs is more efficient and useful for scientific analysis.
         This job should use ``get_query_results`` API to fetch analysis result.
         """
-        kwargs["mode"] = "fast"
         kwargs["preview"] = False
         return self.create_query_job(spl, **kwargs)
 

--- a/pdr_python_sdk/pdr_python_sdk/on_demand_action.py
+++ b/pdr_python_sdk/pdr_python_sdk/on_demand_action.py
@@ -23,14 +23,14 @@ class OnDemandAction(object):
     One time action which process starts on new request and ends after handling it.
     """
 
-    def on_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def on_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         """
         method used to handle request.
         """
         raise NotImplemented('method [on_request()] is not yet implemented')
 
 
-def run(clz, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+def run(clz, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
 
     # config logging
     config_logging()

--- a/pdr_python_sdk/pdr_python_sdk/spl/spl_base_command.py
+++ b/pdr_python_sdk/pdr_python_sdk/spl/spl_base_command.py
@@ -31,10 +31,10 @@ class SplBaseCommand(OnDemandAction):
         self.lines = []
         self.spl_args = []
 
-    def on_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def on_request(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         self.process_protocol(argv, input_stream, output_stream)
 
-    def process_protocol(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def process_protocol(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         try:
             if argv is None:
                 argv = sys.argv
@@ -53,7 +53,7 @@ class SplBaseCommand(OnDemandAction):
             self.metainfo['error_traceback'] = "{}".format(traceback.format_exc())
             send_packet(output_stream, self.metainfo, [])
 
-    def process_data(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def process_data(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         """
         To be implemented
         """

--- a/pdr_python_sdk/pdr_python_sdk/spl/spl_packet_utils.py
+++ b/pdr_python_sdk/pdr_python_sdk/spl/spl_packet_utils.py
@@ -141,7 +141,7 @@ def format_field(part):
     return value
 
 
-def send_packet(output_stream=sys.stdout.buffer, meta_info=None, lines=None):
+def send_packet(output_stream=sys.__stdout__.buffer, meta_info=None, lines=None):
     """
     Send data in packets
     """

--- a/pdr_python_sdk/pdr_python_sdk/spl/spl_streaming_batch_command.py
+++ b/pdr_python_sdk/pdr_python_sdk/spl/spl_streaming_batch_command.py
@@ -18,7 +18,7 @@ from .spl_base_command import SplBaseCommand
 
 
 class SplStreamingBatchCommand(SplBaseCommand):
-    def process_data(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def process_data(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         while True:
             execute_meta = self.process_protocol_execute(input_stream)
             resp = self.streaming_handle(self.lines)

--- a/pdr_python_sdk/pdr_python_sdk/spl/spl_streaming_chunk_command.py
+++ b/pdr_python_sdk/pdr_python_sdk/spl/spl_streaming_chunk_command.py
@@ -19,7 +19,7 @@ from .spl_base_command import SplBaseCommand
 
 class SplStreamingChunkCommand(SplBaseCommand):
 
-    def process_data(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.stdout.buffer):
+    def process_data(self, argv=None, input_stream=sys.stdin.buffer, output_stream=sys.__stdout__.buffer):
         if argv is None:
             argv = sys.argv
         while True:

--- a/pdr_python_sdk/setup.py
+++ b/pdr_python_sdk/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pdr-python-sdk",
-    version="1.0.6",
+    version="1.0.7",
     keywords=["pip", "qiniu", "pandora", "sdk"],
     description="pandora python sdk, include customapi, customoperation, kvstore",
     license="MIT Licence",

--- a/pdr_python_sdk/tests/_sensitive_test_client.py
+++ b/pdr_python_sdk/tests/_sensitive_test_client.py
@@ -178,13 +178,26 @@ class TestClientMethods(unittest.TestCase):
         """
         self.conn.get_query_mapping("repo=_frontend_error")
 
+    def test_search_manager_conn(self):
+        """
+        使用high level的搜索接口
+        :return:
+        """
+        sm = pdr_python_sdk.SearchManager(
+            scheme=self.conn.scheme,
+            host=self.conn.host,
+            port=self.conn.port,
+            token=self.conn.token
+        )
+        sm.query("repo=_frontend_error", start=0, end=int(time.time() * 1000), verbose=True)
+
     def test_search_manager(self):
         """
         使用high level的搜索接口
         :return:
         """
         sm = pdr_python_sdk.SearchManager(self.conn)
-        sm.query("repo=_frontend_error", start=0, end=int(time.time() * 1000))
+        sm.query("repo=_frontend_error", start=0, end=int(time.time() * 1000), verbose=True)
 
     def test_search_manager_pandas(self):
         """

--- a/pdr_python_sdk/tests/test_api.py
+++ b/pdr_python_sdk/tests/test_api.py
@@ -24,7 +24,7 @@ class TestClientMethods(unittest.TestCase):
         Check the runner method
         """
         run(HelloWorldApi, ["/bin/test_api.py app_root/bin/libs", "app_root/bin/libs"], sys.stdin.buffer,
-            sys.stdout.buffer)
+            sys.__stdout__.buffer)
 
 
 if __name__ == "__main__":

--- a/pdr_python_sdk/travis/run_on_pull_requests.sh
+++ b/pdr_python_sdk/travis/run_on_pull_requests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cd pdr_python_sdk && pytest --cov=pdr_python_sdk/ ./tests/test_* && mv .coverage ../
+cd pdr_python_sdk && pytest --cov=pdr_python_sdk/ ./tests/test_* 


### PR DESCRIPTION
Problem: 
When using jupyter notebook to import pdr_python_sdk, it will crash, and raise exception of OutStream does not have buffer attribute. ` 'outstream' object has no attribute 'buffer'`

Reason:
Jupyter will use its own out stream class ipykernel.iostream.OutStream, but not _io.TextIOWrapper in sys package. So we need to use sys.__stdout__ but not sys.stdout directly

因为Jupyter 会将 sys.stdout 使用自己的实现类覆盖掉 ipykernel.iostream.OutStream 使用了这个类。而非原生的类。所以导致我们的代码在引用到 sys.stdout 的时候就会崩溃。修改方式是将 sys.stdout 替换为 sys.__stdout__