### PR TITLE
[PDR-12701]增加本地测试API的功能

### DIFF
--- a/pdr_python_sdk/pdr_python_sdk/api/on_demand_api.py
+++ b/pdr_python_sdk/pdr_python_sdk/api/on_demand_api.py
@@ -125,8 +125,8 @@ class OnDemandApi(OnDemandAction):
                 response = self.handle_data(packet.body())
                 self.write_packet(ApiResponsePacket(1, response))
                 pass
-            except:
-                self.write('error when handling data')
+            except Exception as e:
+                self.write('error when handling data : {}'.format(e))
                 raise
 
         if packet.is_end():

--- a/pdr_python_sdk/pdr_python_sdk/api/packet.py
+++ b/pdr_python_sdk/pdr_python_sdk/api/packet.py
@@ -12,7 +12,6 @@ limitations under the License.
 """
 
 import json
-import logging
 
 
 class ApiRequestPacket(object):
@@ -91,14 +90,9 @@ class ApiRequestPacket(object):
         read request packet from input stream
         @param input_stream: input stream that request data will be read from
         """
-        while True:
-            opcode_str = input_stream.readline().decode('utf-8')
-            if opcode_str == b'':
-                return False
-            if opcode_str != b'\n':
-                # ignore extra newlines before opcode
-                break
-            break
+        opcode_str = input_stream.readline().decode('utf-8')
+        if len(opcode_str) <= 0:
+            return False
         self.__opcode = int(opcode_str)
         len_str = input_stream.readline().decode("utf-8")
         self.__body_length = int(len_str)
@@ -135,11 +129,12 @@ class ApiResponsePacket(object):
 
 
 def _parse_body(body):
-    return ApiPacketBody(**json.loads(body))
+    params = json.loads(body)
+    return ApiPacketBody(**params)
 
 
 class ApiPacketBody(object):
-    def __init__(self, metadata, request):
+    def __init__(self, metadata=None, request=None):
         if metadata is None:
             self.__metadata = None
         else:

--- a/pdr_python_sdk/pdr_python_sdk/api/response.py
+++ b/pdr_python_sdk/pdr_python_sdk/api/response.py
@@ -13,6 +13,9 @@ limitations under the License.
 
 import json
 
+HTTP_CODE_KEY = "http_code"
+ACTUAL_RESPONSE_KEY = "actual_response"
+
 
 class Response(object):
     """
@@ -24,5 +27,8 @@ class Response(object):
         self.actual_response = actual_response
 
     def to_string(self):
-        return '{"http_code":' + str(self.http_code) + ',"actual_response":' + json.dumps(
-            self.actual_response) + '}'
+        response = {
+            HTTP_CODE_KEY: self.http_code,
+            ACTUAL_RESPONSE_KEY: self.actual_response,
+        }
+        return json.dumps(response)

--- a/pdr_python_sdk/pdr_python_sdk/tools/mock_tools.py
+++ b/pdr_python_sdk/pdr_python_sdk/tools/mock_tools.py
@@ -1,0 +1,57 @@
+import io
+import json
+import sys
+
+from pdr_python_sdk.api import ApiRequestPacket, HTTP_CODE_KEY, ACTUAL_RESPONSE_KEY
+from pdr_python_sdk.on_demand_action import run
+
+
+def gen_api_request_packet(opcode, body=""):
+    """
+    Generate api request packet
+    """
+    return "{}\n{}\n{}".format(opcode, len(body), body)
+
+
+def mock_api_request(custom_api_cls,
+                     method="GET", header={}, param={}, body="", uuid="", path=""):
+    """
+    Mock api request to test custom api
+    """
+    request = {
+        "method": method,
+        "path": path,
+        "requestBody": body,
+        "uuid": uuid,
+    }
+
+    if len(param) > 0:
+        param["param"] = param
+    if len(header) > 0:
+        param["header"] = header
+
+    opcode = ApiRequestPacket.OPCODE_REQUEST_INIT | \
+             ApiRequestPacket.OPCODE_REQUEST_DATA | \
+             ApiRequestPacket.OPCODE_REQUEST_END
+    body = json.dumps({"request": request})
+    request_packet = gen_api_request_packet(opcode, body)
+
+    in_stream = io.BytesIO(request_packet.encode("utf-8"))
+    in_stream.seek(0)
+
+    out_stream = io.BytesIO()
+    run(custom_api_cls, sys.argv, in_stream, out_stream)
+    out_stream.seek(0)
+
+    # opcode
+    int(out_stream.readline().decode("utf-8").strip())
+    # body_length
+    len_str = out_stream.readline().decode("utf-8")
+    body_length = int(len_str)
+    # response
+    response_str = out_stream.read(body_length).decode("utf-8")
+    body = json.loads(response_str)
+
+    in_stream.close()
+    out_stream.close()
+    return body[HTTP_CODE_KEY], body[ACTUAL_RESPONSE_KEY]

--- a/pdr_python_sdk/pdr_python_sdk/tools/mock_tools.py
+++ b/pdr_python_sdk/pdr_python_sdk/tools/mock_tools.py
@@ -14,9 +14,11 @@ def gen_api_request_packet(opcode, body=""):
 
 
 def mock_api_request(custom_api_cls,
-                     method="GET", header={}, param={}, body="", uuid="", path=""):
+                     method="GET", header={}, param={}, body="", uuid="", path="", metadata=None):
     """
     Mock api request to test custom api
+
+    metadata = {"server_uri": "http://localhost:xxxx/", "session_key":"xxxxx"}
     """
     request = {
         "method": method,
@@ -33,7 +35,12 @@ def mock_api_request(custom_api_cls,
     opcode = ApiRequestPacket.OPCODE_REQUEST_INIT | \
              ApiRequestPacket.OPCODE_REQUEST_DATA | \
              ApiRequestPacket.OPCODE_REQUEST_END
-    body = json.dumps({"request": request})
+
+    full_request = {"request": request}
+    if metadata:
+        full_request["metadata"] = metadata
+
+    body = json.dumps(full_request)
     request_packet = gen_api_request_packet(opcode, body)
 
     in_stream = io.BytesIO(request_packet.encode("utf-8"))

--- a/pdr_python_sdk/setup.py
+++ b/pdr_python_sdk/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pdr-python-sdk",
-    version="1.0.9",
+    version="1.0.10",
     keywords=["pip", "qiniu", "pandora", "sdk"],
     description="pandora python sdk, include customapi, customoperation, kvstore",
     license="MIT Licence",

--- a/pdr_python_sdk/tests/test_api.py
+++ b/pdr_python_sdk/tests/test_api.py
@@ -1,9 +1,13 @@
 import sys
 import unittest
+import json
+import io
 
+from pdr_python_sdk.api import ApiRequestPacket
 from pdr_python_sdk.api.on_demand_api import OnDemandApi
 from pdr_python_sdk.api.response import Response
 from pdr_python_sdk.on_demand_action import run
+from pdr_python_sdk.tools.mock_tools import mock_api_request, gen_api_request_packet
 
 
 class HelloWorldApi(OnDemandApi):
@@ -11,7 +15,10 @@ class HelloWorldApi(OnDemandApi):
     def do_handle_data(self, data):
         if not data.contains_request():
             raise Exception('api data should contain request details')
-        request = data.request()
+        if data.contains_request():
+            request = data.request()
+        if data.contains_metadata():
+            metadata = data.metadata()
         if 'GET' != str.upper(request.method()):
             return Response(405, 'unsupported method [{}]'.format(str.upper(request.method()))).to_string()
         return Response(204, [{"hello": "world"}]).to_string()
@@ -25,6 +32,49 @@ class TestClientMethods(unittest.TestCase):
         """
         run(HelloWorldApi, ["/bin/test_api.py app_root/bin/libs", "app_root/bin/libs"], sys.stdin.buffer,
             sys.__stdout__.buffer)
+
+    def test_mock_api(self):
+        http_code, response_body = mock_api_request(HelloWorldApi, method="GET")
+        self.assertEqual(http_code, 204)
+        self.assertEqual(response_body[0]['hello'], "world")
+
+    def test_mock_api_post(self):
+        http_code, response_body = mock_api_request(HelloWorldApi, method="POST")
+        self.assertEqual(http_code, 405)
+
+    def test_api_request_packet(self):
+        arp = ApiRequestPacket()
+
+        request = {
+            "method": "GET",
+            "path": "path",
+            "requestBody": "{'hello':'world'}",
+            "uuid": "uuid",
+            "param": {"a": 1},
+            "header": {"Content-Type": "application/json"}
+        }
+        metadata = {
+            "server_uri": "localhost",
+            "session_key": "kkkkkkkk",
+        }
+        opcode = 7
+        body = json.dumps({"metadata": metadata, "request": request})
+        body_len = len(body)
+        packet = gen_api_request_packet(opcode, body)
+        in_stream = io.BytesIO(packet.encode("utf-8"))
+        arp.read(in_stream)
+        self.assertEqual(arp.allow_stream(), False)
+        self.assertEqual(arp.opcode(), opcode)
+        self.assertEqual(arp.body_length(), body_len)
+        self.assertEqual(arp.body_length(), body_len)
+        self.assertEqual(arp.body().metadata()["server_uri"], "localhost")
+        reqresult = arp.body().request()
+        self.assertEqual(reqresult.param(), {"a": 1})
+        self.assertEqual(reqresult.uuid(), "uuid")
+        self.assertEqual(reqresult.header(), {"Content-Type": "application/json"})
+        self.assertEqual(reqresult.method(), "GET")
+        self.assertEqual(reqresult.path(), "path")
+        self.assertEqual(reqresult.request_body(), "{'hello':'world'}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
为on_demand_api 增加mock_api_request 接口，支持用户本地进行自定义API测试

自定义API测试起来比较困难，大部分时候必须要上传到pandora平台上才能比较好的进行逻辑测试。为python sdk增加mock请求的接口，支持在本地写单元测试进行逻辑测试