### PR TITLE
[PDR-12810]为模板增加package.json 和前端打包命令

### DIFF
--- a/pdr_python_sdk/pdr_python_sdk/tools/create.py
+++ b/pdr_python_sdk/pdr_python_sdk/tools/create.py
@@ -33,11 +33,30 @@ def create_pandora_app(mockargs=""):
     shutil.rmtree(TEMP_SDK_DIR)
 
     config_file = os.sep.join([app_dir, "app.json"])
+
+    # replace app name & title in app.json
     with open(config_file, 'r') as f:
-        app_config = json.loads(f.read())
-        app_config["name"] = appname
-        app_config["title"] = args.title
-        print(app_config)
+        config = json.loads(f.read())
+        config["name"] = appname
+        config["title"] = args.title
 
     with open(config_file, 'w') as f:
-        f.write(json.dumps(app_config, ensure_ascii=False))
+        f.write(json.dumps(config, ensure_ascii=False))
+
+    # replace app name in package.json
+    package_file = os.sep.join([app_dir, "package.json"])
+    if not os.path.exists(package_file):
+        config = {
+            "name": appname,
+            "version": "0.1.0",
+            "scripts": {
+                "package": "bash ./run.sh package"
+            }
+        }
+    else:
+        with open(package_file, 'r') as f:
+            config = json.loads(f.read())
+            config["name"] = appname
+
+    with open(package_file, 'w') as f:
+        f.write(json.dumps(config, ensure_ascii=False))

--- a/template/README.md
+++ b/template/README.md
@@ -174,6 +174,7 @@ Usage:
 ```
 
 如果在windows/mac 环境下开发，需要向linux环境打包APP，可以使用 docker_build 环境，注意，如果项目依赖C扩展，需要在 Dockerfile 中指定目标的 Python 环境。
+如果需要node环境的话，建议使用 [python-nodejs](https://hub.docker.com/r/nikolaik/python-nodejs) 镜像。
 
 ```
 ./run.sh docker_build

--- a/template/package.json
+++ b/template/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "____PROJECT_NAME____",
+  "version": "0.1.0",
+  "scripts": {
+    "package": "bash ./run.sh package"
+  }
+}

--- a/template/run.sh
+++ b/template/run.sh
@@ -51,11 +51,18 @@ unittest() {
   pytest "${PROJECT_DIR}"/bins/tests/*
 }
 
+build_webapp() {
+  if [ -d webapp ]; then
+    cd "${PROJECT_DIR}"/webapp && npm run build_appserver && cd "${PROJECT_DIR}" || exit
+  fi
+}
+
 package() {
+  build_webapp
   export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
   export COPYFILE_DISABLE=true
   cd "${PROJECT_PARENT_DIR}" || exit
-  tar czf "${PROJECT_NAME}".tar.gz --exclude="venv" --exclude=".git" --exclude=".DS_Store" "${PROJECT_NAME}" || exit
+  tar czf "${PROJECT_NAME}".tar.gz --exclude="venv" --exclude="webapp" --exclude=".git" --exclude=".DS_Store" "${PROJECT_NAME}" || exit
   mkdir "${PROJECT_DIR}"/dist && mv "${PROJECT_NAME}".tar.gz "${PROJECT_DIR}"/dist
 }
 


### PR DESCRIPTION
[PDR-12810]为模板增加package.json 和前端打包命令

1. 对于pandora团队自身维护的app， 其中必须包含package.json文件。文件格式如下

```javascript
{
            "name": "appname",
            "version": "0.1.0",
            "scripts": {
                "package": "bash ./run.sh package"
            }
}
```

scripts 的 package 字段描述项目打包脚本。python和nodejs各不相同，但是行为是必须在 dist/ 目录下生成tar.gz 包

2. 如果app中既包含前端又包含后端，组织格式是按照后端app的组织形式，中加入webapp目录，存放原本放置于 develop 目录下的源代码文件。并且将其他目录的文件进行融合，如，将visualizations.json 放置于 resources 目录下。

3. 前端需要提供一个 npm run build_appserver 的命令。这个命令主要是build 前端项目，并且将编译产物拷贝到项目顶层 appserver 目录下。（无论是前后端APP或者纯前端APP都是这样）

4. 后端./run.sh package 命令修改逻辑，首先先build前端代码，然后build 后端代码并且打包