### PR TITLE
测试pyarrow库的性能

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,6 @@ class Foobar(SplStreamingBatchCommand):
 ## 代码许可
 
 Apache-2.0 .详情见 [License文件](https://github.com/qiniu/pandora-python-sdk.v2/blob/main/LICENSE).
+
+
+

--- a/pdr_python_sdk/pdr_python_sdk/spl/spl_packet_utils_v2.py
+++ b/pdr_python_sdk/pdr_python_sdk/spl/spl_packet_utils_v2.py
@@ -1,0 +1,93 @@
+"""
+Copyright 2020 Qiniu Cloud (qiniu.com)
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import sys
+import pyarrow as pa
+import pandas as pd
+
+TYPE_STRING = 0
+TYPE_INT = 1
+TYPE_FLOAT = 2
+TYPE_NULL = 3
+TYPE_BOOLEAN = 4
+TYPE_ARRAY = 5
+
+
+def parse_head(input_stream=sys.stdin.buffer):
+    """
+    Parse the chunked protocol
+
+    format: chunked 2.0,<meta_length>,<body_length>\n
+    encoding utf-8
+    """
+    try:
+        header = input_stream.readline().decode("utf-8")
+    except Exception as error:
+        raise RuntimeError('Failed to read spl protocol header: {}'.format(error))
+    parts = str.split(header, ",")
+    meta_length = int(parts[1])
+    body_length = int(parts[2])
+
+    return meta_length, body_length
+
+
+def parse_meta(input_stream=sys.stdin.buffer, length=0):
+    """
+    Parse the chunked protocol
+
+    format: {}
+    encoding utf-8
+    """
+    try:
+        meta_body = input_stream.read(length).decode("utf-8")
+        metainfo = json.loads(meta_body)
+    except Exception as error:
+        raise RuntimeError('Failed to parser spl protocol meta: {}'.format(error))
+
+    return metainfo
+
+
+def send_packet(output_stream=sys.__stdout__.buffer, meta_info=None, df=None):
+    """
+    Send data in packets
+    """
+    if meta_info is None:
+        meta_info = {}
+    if df is None:
+        df = pd.DataFrame()
+    meta = json.dumps(meta_info).encode("utf-8")
+
+    # body = convert_body_to_str(lines).encode("utf-8")
+    sink = pa.BufferOutputStream()
+    batch = pa.record_batch(df)
+    writer = pa.ipc.new_stream(sink, batch.schema)
+    writer.write_batch(batch)
+
+    head = ('chunked 2.0,%s,%s\n' % (len(meta), len(sink.getvalue().size))).encode("utf-8")
+    output_stream.write(head)
+    output_stream.write(meta)
+
+    if len(df) > 0:
+        output_stream.write(sink.getvalue().to_pybytes())
+
+    output_stream.flush()
+    return
+
+
+def parse_body(input_stream=sys.stdin.buffer, length=0):
+    """
+    Parse body into records
+    """
+    buf = pa.py_buffer(input_stream.read(length))
+    return pa.ipc.open_stream(buf).read_all()

--- a/pdr_python_sdk/setup.py
+++ b/pdr_python_sdk/setup.py
@@ -29,6 +29,7 @@ setup(
         "urllib3",
         "pyyaml",
         "GitPython",
-        "pandas"
+        "pandas",
+        "pyarrow"
     ]
 )

--- a/pdr_python_sdk/tests/test_spl_packet_utils.py
+++ b/pdr_python_sdk/tests/test_spl_packet_utils.py
@@ -3,6 +3,7 @@ import io
 from pdr_python_sdk.spl import *
 
 
+
 class TestClientMethods(unittest.TestCase):
 
     def test_parse_head(self):
@@ -89,3 +90,22 @@ class TestClientMethods(unittest.TestCase):
 
     def test_decode_string(self):
         self.assertEqual(decode_string("\\t\\n"), "\t\n")
+
+    def test_parse_body_bench(self):
+        lines = ["cnt\t_raw\t_time\thost\torigin\tsourcetype"]
+        for i in range(1000):
+            lines.append("\t".join(
+                [
+                    f"{TYPE_INT},{i}",
+                    f"{TYPE_STRING},this is a log, it is a little long, but it's just a string, with no surprise",
+                    f"{TYPE_INT},{1612774891 + i}",
+                    f"{TYPE_STRING},192.168.1.1",
+                    f"{TYPE_STRING},/path/to/your/log.txt",
+                    f"{TYPE_STRING},test_log",
+                ]
+            ))
+        large_body = "\n".join(lines)
+        body_bytes = large_body.encode("utf-8")
+        print(f"size is ============ {len(body_bytes)}")
+        for i in range(5000):
+            lines = parse_body(io.BytesIO(body_bytes), len(body_bytes))

--- a/pdr_python_sdk/tests/test_spl_packet_utils_v2.py
+++ b/pdr_python_sdk/tests/test_spl_packet_utils_v2.py
@@ -1,0 +1,71 @@
+import unittest
+import io
+from pdr_python_sdk.spl.spl_packet_utils_v2 import *
+import pyarrow as pa
+import pandas as pd
+
+
+class TestClientMethods(unittest.TestCase):
+
+    def test_parse_head(self):
+        meta_length, body_length = parse_head(input_stream=io.BytesIO(b"format: chunked 2.0,10,20\n"))
+        self.assertEqual(meta_length, 10)
+        self.assertEqual(body_length, 20)
+
+    def test_parse_meta(self):
+        metainfo = {
+            "args": ["a=1", "b"],
+            "dispatch_dir": "/a/b/c",
+            "owner": "abc@def.com",
+            "command": "sample a=1 b",
+            "app": "YourApp",
+            "session_key": "xxxxxxx",
+            "username": "def@abc.com",
+            "server_uri": "localhost:8080"
+        }
+        metabytes = json.dumps(metainfo).encode("utf-8")
+        ret = parse_meta(io.BytesIO(metabytes), len(metabytes))
+        for key in ret:
+            self.assertEqual(ret[key], metainfo[key])
+
+    def test_parse_body(self):
+        data = [
+            pa.array([1, 2, 3, 4])
+        ]
+        batch = pa.record_batch(data, names=["f0"])
+        sink = pa.BufferOutputStream()
+        writer = pa.ipc.new_stream(sink, batch.schema)
+        writer.write_batch(batch)
+        body = sink.getvalue().to_pybytes()
+
+        df = parse_body(io.BytesIO(body), len(body))
+
+    def test_parse_body_bench(self):
+        large_data = [
+            {
+                "cnt": i,
+                "_raw": "this is a log, it is a little long, but it's just a string, with no surprise",
+                "_time": 1612774891 + i,
+                "host": "192.168.1.1",
+                "origin": "/path/to/your/log.txt",
+                "sourcetype": "test_log",
+            } for i in range(1000)
+        ]
+        large_df = pd.DataFrame.from_records(large_data)
+        batch = pa.record_batch(large_df)
+        sink = pa.BufferOutputStream()
+        writer = pa.ipc.new_stream(sink, batch.schema)
+        writer.write_batch(batch)
+        body = sink.getvalue().to_pybytes()
+        print(f"size is ======== {len(body)}")
+        n = 10
+        n = 5000
+        import pyarrow.compute as pc
+        for i in range(n):
+            table = parse_body(io.BytesIO(body), len(body))
+
+            # 向量化计算
+            newtable = table.append_column("f1", pc.add(table.column("cnt"), 2))
+
+            # 转成pandas dataframe
+            # df = table.to_pandas()


### PR DESCRIPTION
spl_packet_utils_v2.py 是protocol 解析的逻辑

tests/test_spl_packet_utils_v2.py  test_parse_body_bench 是500w条数据的解析的测试代码
tests/test_spl_packet_utils.py 这里是相对应的v1版本测试case

大致数据是，v2 版本由于zero-copy，完成解析工作时间是毫秒级（可以看做几乎不花时间在解析上）。如果转成pandas的dataframe 大概是9秒左右。
v1版本从csv 到解析工作完成需要45秒左右时间。

**初步结论**，我们如果把ipc 格式从csv 迁移到arrow ipc格式上，起码解析可以提升5倍左右的效率。如果场景允许，并且可以使用向量化计算，那可以更加提速到50倍左右。