### PR TITLE
 [PDR-15041][fix(app)]:修复updateByQuery接口设置insert=True时报错

### DIFF
--- a/pdr_python_sdk/pdr_python_sdk/storage/client.py
+++ b/pdr_python_sdk/pdr_python_sdk/storage/client.py
@@ -170,6 +170,8 @@ class StorageTableData(object):
         :param data: The keys to update with new value. type ``dict`` or ``string``
         :return: Result of PUT request
         """
+        if kwargs['insert']:
+            kwargs['insert'] = 'true'
         return self.service.put(self.path, body=get_object(data), fields=kwargs)
 
     def batch_save(self, datas):


### PR DESCRIPTION
在调用updateByQuery接口时，如果设置了insert=True参数，会报错"Failed to parse value [True] as only [true] or [false] are allowed."